### PR TITLE
Check for null pointer in alan.c, magic_word_found()

### DIFF
--- a/alan.c
+++ b/alan.c
@@ -28,6 +28,8 @@ static uint32 read_alan_int_at(byte *from)
 }
 
 static bool magic_word_found(byte *story_file) {
+  if(story_file == NULL)
+    return false;
   return memcmp(story_file,"ALAN",4) == 0;
 }
 


### PR DESCRIPTION
The Clang static analyzer warns about a potential null pointer passed to memcmp() in magic_word_found().