### PR TITLE
(Request for comments) Make babel recognise more Level 9 games

### DIFF
--- a/level9.c
+++ b/level9.c
@@ -392,6 +392,8 @@ static int v1_recognition(unsigned char *sf, int32 extent, char **ifid)
 static int v3_recognition_phase (int phase,unsigned char *sf, int32 extent, int32 *l, unsigned char *c)
 {
   int32 end, i, j, ll;
+  if (sf == NULL || *sf == '\0')
+      return 0;
   ll=0;
   for (i=0;i<extent-20;i++)
   {
@@ -400,13 +402,13 @@ static int v3_recognition_phase (int phase,unsigned char *sf, int32 extent, int3
     end=*l+i;
     if (phase!=3)
     {
-    if (end <= (extent - 2) &&
+    if (end <= extent &&
        (
         ((phase == 2) ||
-        (((sf[end-1] == 0) &&
-         (sf[end-2] == 0)) ||
-        ((sf[end+1] == 0) &&
-         (sf[end+2] == 0))))
+        (((end >= 1 && sf[end-1] == 0) &&
+         (end >= 2 && sf[end-2] == 0)) ||
+        ((end <= extent - 2 && sf[end+1] == 0) &&
+         (end <= extent - 3 && sf[end+2] == 0))))
         && (*l>0x4000) && (*l<=0xdb00)))
       if ((*l!=0) && (sf[i+0x0d] == 0))
        for (j=i;j<i+16;j+=2)
@@ -416,7 +418,7 @@ static int v3_recognition_phase (int phase,unsigned char *sf, int32 extent, int3
      }
      else
      {
-      if ((extent>0x0fd0) && (end <= (extent - 2)) &&
+      if ((extent>0x0fd0) && (end <= extent) &&
          (((read_l9_int(sf+i+2) + read_l9_int(sf+i+4))==read_l9_int(sf+i+6))
                     && (read_l9_int(sf+i+2) != 0) && (read_l9_int(sf+i+4)) != 0) &&
          (((read_l9_int(sf+i+6) + read_l9_int(sf+i+8)) == read_l9_int(sf+i+10))


### PR DESCRIPTION
See https://github.com/angstsmurf/spatterlight/issues/11

Some Level 9 games are not recognised by Babel, and the reason seems to be that Babel does not read all the way to the end of the file when calculating the checksum. 

This change makes it recognise the files, and doesn't seem to cause any problems in Spatterlight, but looking through the source, I can't really understand why it would subtract 2 from the file extent in the first place. Can anyone explain?

EDIT: Code has been reworked, see comments below.