### PR TITLE
Use UUID://...// syntax in ifiction:ifid

### DIFF
--- a/test/html/Test-Game-Meta-Prefix.html
+++ b/test/html/Test-Game-Meta-Prefix.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta prefix="ifiction: http://babel.ifarchive.org/protocol/iFiction/" property="ifiction:ifid" content="448E73DF-2D2F-47E7-A494-A46B40D4CFB4">
+<meta prefix="ifiction: http://babel.ifarchive.org/protocol/iFiction/" property="ifiction:ifid" content="UUID://448E73DF-2D2F-47E7-A494-A46B40D4CFB4//">
 <title>Test Game</title>
 </head>
 

--- a/test/html/Test-Game-Meta-Prefix.html
+++ b/test/html/Test-Game-Meta-Prefix.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta prefix="ifiction: http://babel.ifarchive.org/protocol/iFiction/" property="ifiction:ifid" content="UUID://448E73DF-2D2F-47E7-A494-A46B40D4CFB4//">
+<meta prefix="ifiction: https://babel.ifarchive.org/protocol/iFiction/" property="ifiction:ifid" content="UUID://448E73DF-2D2F-47E7-A494-A46B40D4CFB4//">
 <title>Test Game</title>
 </head>
 

--- a/test/html/Test-Game-Meta.html
+++ b/test/html/Test-Game-Meta.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta property="ifiction:ifid" content="448E73DF-2D2F-47E7-A494-A46B40D4CFB3">
+<meta property="ifiction:ifid" content="UUID://448E73DF-2D2F-47E7-A494-A46B40D4CFB3//">
 <title>Test Game</title>
 </head>
 


### PR DESCRIPTION
As I suggested on intfiction https://intfiction.org/t/babel-for-html/53945/15?u=dfabulich we can just standardize on `UUID://...//` and have the treaty recommend putting the data in a `<meta property="ifiction:ifid">` tag, but also detect the UUID in a comment or whatever.

This gets us out of the business of hand-parsing HTML in cases where we can detect `UUID://...//`.