### PR TITLE
Don't require a space after #! shebang for script

### DIFF
--- a/executable.c
+++ b/executable.c
@@ -32,7 +32,7 @@ static struct exetype magic[]= {
     { elfmagic, "ELF", 4 },
     { javamagic, "JAVA", 4 },
     { amigamagic, "AMIGA", 4 },
-    { "#! ", "SCRIPT", 3 },
+    { "#!", "SCRIPT", 2 },
     { machomagic, "MACHO",4 },
     { "APPL", "MAC",4 },
     { NULL, NULL, 0 }


### PR DESCRIPTION
Scripts begin with a #! "shebang" to tell the operating system which interpreter to use. Babel detects the shebang as a "magic" sequence of characters, identifying the file as an executable of type `SCRIPT`.

Babel incorrectly assumed that the shebang will have a space after it, i.e. `#! /usr/bin/python`, but it's common for scripts to include no space, e.g. `#!/usr/bin/python`.

After this commit, Babel detects #! as the start of a script, with or without a space.