### PR TITLE
Add a -nowarn argument

### DIFF
--- a/babel.c
+++ b/babel.c
@@ -30,7 +30,7 @@ extern "C" {
 }
 #endif
 
-char *fn;
+char *fn = NULL;
 
 /* checked malloc function */
 void *my_malloc(int, char *);
@@ -95,12 +95,15 @@ int main(int argc, char **argv)
     int ok=1,i, l, ll;
     FILE *f;
     char *md=NULL;
+    
     /* Set the input filename.  Note that if this is invalid, babel should
        abort before anyone notices
     */
-    fn=argv[2];
+    if (argc >= 3)
+        fn=argv[2];
+    else
+        ok=0;
 
-    if (argc < 3) ok=0;
     /* Detect the presence of the "-to <directory>" argument.
      */
     if (ok && argc >=5 && strcmp(argv[argc-2], "-to")==0)

--- a/babel.c
+++ b/babel.c
@@ -31,6 +31,7 @@ extern "C" {
 #endif
 
 char *fn = NULL;
+int show_warnings = 1;
 
 /* checked malloc function */
 void *my_malloc(int, char *);
@@ -95,6 +96,13 @@ int main(int argc, char **argv)
     int ok=1,i, l, ll;
     FILE *f;
     char *md=NULL;
+
+    if (argc >= 2 && !strcmp(argv[1], "-nowarn")) {
+        /* Trim this argument from the beginning. */
+        argv++;
+        argc--;
+        show_warnings = 0;
+    }
     
     /* Set the input filename.  Note that if this is invalid, babel should
        abort before anyone notices
@@ -108,6 +116,7 @@ int main(int argc, char **argv)
      */
     if (ok && argc >=5 && strcmp(argv[argc-2], "-to")==0)
     {
+        /* Trim this argument from the end. */
         todir=argv[argc-1];
         argc-=2;
     }

--- a/babel.c
+++ b/babel.c
@@ -239,8 +239,10 @@ int main(int argc, char **argv)
             {
                 getcwd(cwd,512);
                 chdir(todir);
-                if (!babel_get_authoritative() && strcmp(argv[1],"-format"))
-                    printf("Warning: Story format could not be positively identified. Guessing %s\n",lt);
+                if (!babel_get_authoritative() && strcmp(argv[1],"-format")) {
+                    if (show_warnings)
+                        printf("Warning: Story format could not be positively identified. Guessing %s\n",lt);
+                }
                 functions[i].story();
 
                 chdir(cwd);

--- a/babel.h
+++ b/babel.h
@@ -25,6 +25,8 @@
 extern "C" {
 #endif
 
+extern int show_warnings;
+
 /* Functions from babel_story_functions.c
  *
  * Each of these assumes that the story file has been loaded by babel_handler

--- a/babel_ifiction_functions.c
+++ b/babel_ifiction_functions.c
@@ -107,7 +107,7 @@ void babel_ifiction_ifid(char *md)
 
 }
 
-static char isok;
+static int haserrors, haswarnings;
 
 static void examine_tag(struct XMLTag *xtg, void *ctx)
 {
@@ -126,10 +126,17 @@ static void examine_tag(struct XMLTag *xtg, void *ctx)
 static void verify_eh(char *e, void *ctx)
 {
  if (*((int *)ctx) < 0) return;
- if (*((int *)ctx) || strncmp(e,"Warning",7))
-  { isok=0;
+ if (strncmp(e,"Warning",7)) {
+  /* Error */
+  haserrors=1;
+  fprintf(stderr, "%s\n",e);
+ }
+ else {
+  /* Warning */
+  haswarnings=1;
+  if (*((int *)ctx))
    fprintf(stderr, "%s\n",e);
-  }
+ }
 }
 
 
@@ -143,29 +150,30 @@ void babel_ifiction_fish(char *md)
 void deep_ifiction_verify(char *md, int f)
 {
  struct IFiction_Info ii;
- int i=0;
+ int errmode=0;
  ii.wmode=0;
- isok=1;
+ haserrors = haswarnings = 0;
  strcpy(ii.ifid,"UNKNOWN");
- ifiction_parse(md,examine_tag,&ii,verify_eh,&i);
- if (f&& isok) printf("Verified %s\n",ii.ifid);
+ ifiction_parse(md,examine_tag,&ii,verify_eh,&errmode);
+ if (f&& !haserrors) printf("Verified %s\n",ii.ifid);
 }
+
 void babel_ifiction_verify(char *md)
 {
  deep_ifiction_verify(md,1);
-
 }
 
 
 void babel_ifiction_lint(char *md)
 {
  struct IFiction_Info ii;
- int i=1;
+ int errmode=show_warnings;
  ii.wmode=1;
- isok=1;
+ haserrors = haswarnings = 0;
  strcpy(ii.ifid,"UNKNOWN");
- ifiction_parse(md,examine_tag,&ii,verify_eh,&i);
- if (isok) printf("%s conforms to iFiction style guidelines\n",ii.ifid);
+ ifiction_parse(md,examine_tag,&ii,verify_eh,&errmode);
+ if (!(haserrors || haswarnings)) printf("%s conforms to iFiction style guidelines\n",ii.ifid);
+ else if (!haserrors) printf("%s conforms to guidelines with warnings\n",ii.ifid);
 }
 
 

--- a/babel_ifiction_functions.c
+++ b/babel_ifiction_functions.c
@@ -120,6 +120,9 @@ static void examine_tag(struct XMLTag *xtg, void *ctx)
  }
 
 }
+
+/* The ctx argument is -1 to ignore errors and warnings; 0 to only show
+   errors; 1 to show errors and warnings. */
 static void verify_eh(char *e, void *ctx)
 {
  if (*((int *)ctx) < 0) return;

--- a/babel_ifiction_functions.c
+++ b/babel_ifiction_functions.c
@@ -173,7 +173,7 @@ void babel_ifiction_lint(char *md)
  strcpy(ii.ifid,"UNKNOWN");
  ifiction_parse(md,examine_tag,&ii,verify_eh,&errmode);
  if (!(haserrors || haswarnings)) printf("%s conforms to iFiction style guidelines\n",ii.ifid);
- else if (!haserrors) printf("%s conforms to guidelines with warnings\n",ii.ifid);
+ else if (!haserrors) printf("%s does not conform to guidelines\n",ii.ifid);
 }
 
 

--- a/babel_multi_functions.c
+++ b/babel_multi_functions.c
@@ -178,7 +178,8 @@ static void _babel_multi_blorb(char *outfile, char **args, char *todir , int arg
     }
     if (babel_get_length() != babel_get_story_length())
     {
-        fprintf(stderr,"Warning: Story file will be extacted from container before blorbing\n");
+        if (show_warnings)
+            fprintf(stderr,"Warning: Story file will be extacted from container before blorbing\n");
     }
     /* printf("Completing ifiction\n");*/
     md=deep_complete_ifiction(args[1],buffer,b2);


### PR DESCRIPTION
The `-nowarn` option suppresses all warnings.

Because the Babel tool rocks that 1991 code style, the `-nowarn` option must be first. E.g.

    babel -nowarn -ifid test.file

In making the tool behavior consistent, I wound up extending the `-lint` option a bit. It can now print

> FILE conforms to iFiction style guidelines

or

> FILE conforms to guidelines with warnings

In the latter case, the warnings are printed before the summary unless `-nowarn` is set. If there are errors, they are always printed.
