### PR TITLE
Authoritatively claim a file as blorb if it's an IFF of type IFRS

### DIFF
--- a/blorb.c
+++ b/blorb.c
@@ -246,7 +246,7 @@ static int32 claim_story_file(void *story_file, int32 extent)
         memcmp(story_file,"FORM",4) ||
         memcmp((char *)story_file+8,"IFRS",4) 
     ) i= INVALID_STORY_FILE_RV;
-    else i= NO_REPLY_RV;
+    else i= VALID_STORY_FILE_RV;
  
     return i;
 


### PR DESCRIPTION
Fixes #39

I'm not at all sure this is the right thing to do. There's no documentation here on why this function would never return `VALID_STORY_FILE_RV`. (`git blame` says it's been like this since the initial commit in 2006.)

But it seems to me that if an extensionless file is an IFF of type IFRS, it's just _gotta_ be a blorb, amirite?