### PR TITLE
Blorb detection fixes

### DIFF
--- a/blorb.c
+++ b/blorb.c
@@ -141,7 +141,7 @@ char *blorb_chunk_for_name(char *name)
     int j;
     for(j=0;TranslateExec[j];j+=2)
         if (strcmp(name,TranslateExec[j+1])==0) return TranslateExec[j];
-    for(j=0;j<4 && name[j];j++) buffer[j]=toupper(buffer[j]);
+    for(j=0;j<4 && name[j];j++) buffer[j]=toupper(name[j]);
     while(j<4) buffer[j++]=' ';
     buffer[4]=0;
     return buffer;

--- a/blorb.c
+++ b/blorb.c
@@ -40,6 +40,14 @@ static char *TranslateExec[] = {
     "GLUL", "glulx",
     "TAD2", "tads2",
     "TAD3", "tads3",
+    "HUGO", "hugo",
+    "ALAN", "alan",
+    "ADRI", "adrift",
+    "LEVE", "level9",
+    "AGT ", "agt",
+    "MAGS", "magscrolls",
+    "ADVS", "advsys",
+    "EXEC", "executable",
     NULL, NULL
 };
 


### PR DESCRIPTION
The commit here that adds formats to `TranslateExec` is actually redundant after the fix that's in the first commit. All of the names added will now properly be calculated by `blorb_chunk_for_name()`. Adding these specifically does follow precendent: `ZCOD` and `GLUL` aren't needed, but are listed; and I think it's probably nicer for readers of the code to see the full list.

In any case, 4ac6fcc7c9e0667e1caa2eb38d07ac4fb58e4505 is an actual bug fix, and cbed2a775ea2a2b94f5ac180ffc021471a24ed72 is not.