### PR TITLE
Handle `UUID://...//` marker at the exact EOF

### DIFF
--- a/ifiction.c
+++ b/ifiction.c
@@ -565,7 +565,7 @@ int32 find_uuid_ifid_marker(void *sf, int32 extent, char *output, int32 output_e
                 if (!(isdigit(ch) || isupper(ch) || ch == '-'))
                     break;
             }
-            if (j < extent-2 && ((char *)sf)[j] == '/' && ((char *)sf)[j+1] == '/') {
+            if (j + 1 < extent && ((char *)sf)[j] == '/' && ((char *)sf)[j+1] == '/') {
                 int len = j-(i+7);
                 if (len+1 > extent)
                     return INVALID_USAGE_RV;


### PR DESCRIPTION
Fixes #43

```
dfab: ~/git/babel-tool % ./babel -identify /tmp/test.txt
Warning: Story format could not be positively identified. Guessing executable
No bibliographic data
IFID: 1974A053-7DB0-4103-93A1-767C1382C0B7
executable, 0k, no cover
dfab: ~/git/babel-tool % ./babel -identify /tmp/babel-ifid.zip
Warning: Story format could not be positively identified. Guessing executable
No bibliographic data
IFID: 1974A053-7DB0-4103-93A1-767C1382C0B7
executable, 0k, no cover
```